### PR TITLE
Simplify and improve version pinning and index management:

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,17 +5,20 @@ parts =
     var
     karl
 
-index = http://karlhosting.github.io/karl4/index/
+find-links = http://karlhosting.github.io/karl4
 
 # override any eggs-directory or download-cache settings
 # that might be in ~/.buildout/default.cfg. We have to do this because
 # we're pinning versions using a custom package index instead of
 # using versions.cfg.
-eggs-directory = ${buildout:directory}/eggs
-download-cache =
 
 customization-packages =
     osi
+
+# version pinning:
+show-picked-versions = true
+update-versions-file = versions.cfg
+extends = versions.cfg
 
 [var]
 recipe = z3c.recipe.mkdir

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,364 @@
+[versions]
+
+# Added by buildout at 2017-01-10 10:14:41.656848
+BTrees = 4.3.2
+Chameleon = 2.8.2
+Jinja2 = 2.6
+Mako = 0.4.2
+MarkupSafe = 0.15
+PasteScript = 1.7.4.1
+ProxyTypes = 0.9
+RelStorage = 2.0.0rc1
+SQLAlchemy = 1.0.12
+Sphinx = 1.1.2
+ZEO = 5.0.4
+convertish = 0.5.5
+coverage = 2.85
+docutils = 0.8.1
+dottedish = 0.6
+formish = 0.8.5.3+agendaless
+guillotine = 0.1
+idna = 2.0
+j1m.relstoragejsonsearch = 0.2.1
+karl.external-link-ticket = 3.5
+meld3 = 0.6.8
+mock = 1.3.0
+mr.developer = 1.21
+nose = 1.3.7
+osi = 4.3.1
+pbr = 1.7.0
+persistent = 4.2.2
+pyasn1 = 0.1.9
+pyramid = 1.2.1
+pyramid-debugtoolbar = 1.0.2
+pyramid-formish = 0.2a1
+pyramid-jwtauth = 0.1.3+agendaless
+pyramid-multiauth = 0.1.2
+pyramid-tm = 0.5
+pyramid-zcml = 0.7
+pyramid-zodbconn = 0.3
+repoze.debug = 0.7.1
+repoze.pgtextindex = 1.4
+repoze.postoffice = 0.25
+repoze.profile = 2.0
+repozitory = 1.3
+requests-toolbelt = 0.3.1
+schemaish = 0.5.6
+slowlog = 0.9
+superlance = 0.9
+supervisor = 3.0a8
+validatish = 0.6.4
+venusian = 1.0a1
+waitress = 0.8.9
+z3c.recipe.mkdir = 0.3.1
+zc.buildout = 2.5.2
+zc.recipe.egg = 2.0.2
+zodbpickle = 0.6.0
+zope.component = 3.6.0
+zope.testing = 3.7.3
+
+# Required by:
+# repoze.debug==0.7.1
+Paste = 1.7.5.1
+
+# Required by:
+# PasteScript==1.7.4.1
+# pyramid==1.2.1
+PasteDeploy = 1.5.0
+
+# Required by:
+# karl==4.25.1
+Pillow = 2.6.1
+
+# Required by:
+# pyramid-jwtauth==0.1.3+agendaless
+PyJWT = 1.4.0
+
+# Required by:
+# pyramid-debugtoolbar==1.0.2
+Pygments = 1.4
+
+# Required by:
+# repoze.debug==0.7.1
+WebOb = 1.1.1
+
+# Required by:
+# ZEO==5.0.4
+# ZODB==5.1.1
+# repoze.zodbconn==0.14
+ZConfig = 2.5.1
+
+# Required by:
+# j1m.relstoragejsonsearch==0.2.1
+ZODB = 5.1.1
+
+# Required by:
+# karl==4.25.1
+# repoze.pgtextindex==1.4
+# repoze.postoffice==0.25
+ZODB3 = 3.11.0
+
+# Required by:
+# karl==4.25.1
+admin5 = 0.5
+
+# Required by:
+# karl==4.25.1
+appendonly = 1.0.2
+
+# Required by:
+# RelStorage==2.0.0rc1
+cffi = 1.4.1
+
+# Required by:
+# pyramid-jwtauth==0.1.3+agendaless
+cryptography = 1.2.3
+
+# Required by:
+# repoze.errorlog==0.7
+elementtree = 1.2.6.post20050316
+
+# Required by:
+# cryptography==1.2.3
+enum34 = 1.1.1
+
+# Required by:
+# karl==4.25.1
+feedparser = 4.1
+
+# Required by:
+# mock==1.3.0
+funcsigs = 0.4
+
+# Required by:
+# ZEO==5.0.4
+# trollius==2.1
+futures = 3.0.5
+
+# Required by:
+# karl==4.25.1
+icalendar = 2.0.1-karl3
+
+# Required by:
+# cryptography==1.2.3
+ipaddress = 1.0.15
+
+# Required by:
+# karl==4.25.1
+lxml = 2.2
+
+# Required by:
+# karl==4.25.1
+markdown2 = 1.0.1.11
+
+# Required by:
+# RelStorage==2.0.0rc1
+# repoze.pgtextindex==1.4
+# repozitory==1.3
+# slowlog==0.9
+perfmetrics = 2.0
+
+# Required by:
+# j1m.relstoragejsonsearch==0.2.1
+# repoze.pgtextindex==1.4
+# repozitory==1.3
+psycopg2 = 2.6.2
+
+# Required by:
+# cffi==1.4.1
+pycparser = 2.14
+
+# Required by:
+# repoze.profile==2.0
+pyprof2calltree = 1.1.0
+
+# Required by:
+# karl==4.25.1
+python-dateutil = 1.5
+
+# Required by:
+# karl==4.25.1
+redis = 2.4.11
+
+# Required by:
+# karl.external-link-ticket==3.5
+# karl==4.25.1
+repoze.browserid = 0.3
+
+# Required by:
+# repoze.pgtextindex==1.4
+repoze.catalog = 0.8.3
+
+# Required by:
+# karl==4.25.1
+repoze.depinj = 0.1
+
+# Required by:
+# karl==4.25.1
+repoze.errorlog = 0.7
+
+# Required by:
+# karl==4.25.1
+repoze.evolution = 0.3
+
+# Required by:
+# karl==4.25.1
+repoze.folder = 0.6.2
+
+# Required by:
+# karl==4.25.1
+repoze.lemonade = 0.7.5
+
+# Required by:
+# pyramid==1.2.1
+repoze.lru = 0.4
+
+# Required by:
+# karl==4.25.1
+repoze.monty = 0.1
+
+# Required by:
+# karl==4.25.1
+repoze.sendmail = 4.2+agendaless.6
+
+# Required by:
+# karl.external-link-ticket==3.5
+# karl==4.25.1
+repoze.session = 0.1.1
+
+# Required by:
+# repoze.workflow==0.5
+repoze.sphinx.autointerface = 0.2.1
+
+# Required by:
+# karl==4.25.1
+# repoze.whoplugins.zodb==1.0.1
+repoze.who = 1.0.15
+
+# Required by:
+# karl==4.25.1
+repoze.whoplugins.zodb = 1.0.1
+
+# Required by:
+# karl==4.25.1
+repoze.workflow = 0.5
+
+# Required by:
+# repoze.workflow==0.5
+repoze.zcml = 0.4
+
+# Required by:
+# repoze.postoffice==0.25
+repoze.zodbconn = 0.14
+
+# Required by:
+# karl==4.25.1
+requests = 2.4.3
+
+# Required by:
+# mr.developer==1.21
+setuptools = 31.0.0
+
+# Required by:
+# convertish==0.5.5
+# dottedish==0.6
+simplegeneric = 0.6
+
+# Required by:
+# karl==4.25.1
+# repozitory==1.3
+simplejson = 1.9.2
+
+# Required by:
+# ZEO==5.0.4
+# ZODB==5.1.1
+six = 1.10.0
+
+# Required by:
+# repoze.debug==0.7.1
+threadframe = 0.2
+
+# Required by:
+# ZODB3==3.11.0
+# repoze.pgtextindex==1.4
+# zope.sqlalchemy==0.6.1
+transaction = 2.0.3
+
+# Required by:
+# pyramid==1.2.1
+translationstring = 0.4
+
+# Required by:
+# ZEO==5.0.4
+trollius = 2.1
+
+# Required by:
+# user-agents==1.0.1
+ua-parser = 0.7.2
+
+# Required by:
+# pyramid-multiauth==0.1.2
+unittest2 = 0.5.1
+
+# Required by:
+# karl==4.25.1
+user-agents = 1.0.1
+
+# Required by:
+# karl==4.25.1
+wsgicors = 0.6.0
+
+# Required by:
+# RelStorage==2.0.0rc1
+# ZEO==5.0.4
+# ZODB==5.1.1
+zc.lockfile = 1.0.0
+
+# Required by:
+# ZEO==5.0.4
+zdaemon = 2.0.2
+
+# Required by:
+# pyramid-zodbconn==0.3
+zodburi = 1.0b1
+
+# Required by:
+# pyramid-zcml==0.7
+# repoze.lemonade==0.7.5
+# repoze.workflow==0.5
+zope.configuration = 3.6.0
+
+# Required by:
+# pyramid==1.2.1
+zope.deprecation = 3.5.0
+
+# Required by:
+# repoze.session==0.1.1
+# zope.component==3.6.0
+# zope.schema==3.5.4
+zope.event = 3.4.1
+
+# Required by:
+# zope.schema==3.5.4
+zope.i18nmessageid = 3.5.0
+
+# Required by:
+# repoze.pgtextindex==1.4
+zope.index = 3.6.4
+
+# Required by:
+# RelStorage==2.0.0rc1
+# ZODB==5.1.1
+# karl==4.25.1
+# repozitory==1.3
+# zope.schema==3.5.4
+# zope.sqlalchemy==0.6.1
+zope.interface = 3.8.0
+
+# Required by:
+# repozitory==1.3
+zope.schema = 3.5.4
+
+# Required by:
+# repozitory==1.3
+zope.sqlalchemy = 0.6.1


### PR DESCRIPTION
- Use standard buildout version pinning

- Use http://karlhosting.github.io/karl4 (rather than
  http://karlhosting.github.io/karl4/index) to avoid having to build an index.

- Leverage user's download cache and shared eggs.